### PR TITLE
Added menu entry to adjust current step of encoder

### DIFF
--- a/firmware/Reload Pro.cydsn/config.h
+++ b/firmware/Reload Pro.cydsn/config.h
@@ -60,6 +60,7 @@ typedef struct {
 	int current_setpoint;
     int lower_voltage_limit;
     uint8_t calibrating;
+	uint32 step_size;
 } state_t;
 
 extern state_t state;

--- a/firmware/Reload Pro.cydsn/ui.c
+++ b/firmware/Reload Pro.cydsn/ui.c
@@ -83,8 +83,6 @@ static state_func splashscreen(const void*);
 #define STATE_SPLASHSCREEN {splashscreen, NULL, 0}
 #endif
 
-uint32 current_step = CURRENT_STEP;
-
 const menudata set_stepsize_menu = { 
     "Choose value",
 	{
@@ -213,7 +211,7 @@ static void format_number(int num, const char *suffix, char *out) {
 }
 
 static void adjust_current_setpoint(int delta) {
-	set_current(state.current_setpoint + delta * current_step);
+	set_current(state.current_setpoint + delta * state.step_size);
     uart_printf("set %d\r\n", state.current_setpoint / 1000);
 }
 
@@ -359,7 +357,7 @@ static state_func set_stepsize(const void *arg){
     if(stepsize.func == overlimit)
 	    return stepsize;
     
-    current_step = (uint32)stepsize.arg;
+    state.step_size = (uint32)stepsize.arg;
         
     return (state_func)STATE_MAIN;
 }

--- a/firmware/Reload Pro.cydsn/utils.c
+++ b/firmware/Reload Pro.cydsn/utils.c
@@ -22,6 +22,7 @@
 void setup() {
 	state.current_setpoint = -1;
     state.lower_voltage_limit = -1;
+	state.step_size = CURRENT_STEP;
 
 	set_current(0);
 	


### PR DESCRIPTION
Added menu entry to adjust the step size of the encoder. The following values are selectable: 1, 2, 5, 10, 20, 50, 100, 200, 500 mA.
The default value after reset is 20mA as defined in config.h: CURRENT_STEP.

This is intended as a temporary workaround for issues #27 an #43 until a better solution is implemented.
