### PR TITLE
Long button press event

### DIFF
--- a/firmware/Reload Pro.cydsn/tasks.h
+++ b/firmware/Reload Pro.cydsn/tasks.h
@@ -23,6 +23,7 @@ extern xQueueHandle comms_queue;
 typedef enum {
 	UI_EVENT_NONE,
 	UI_EVENT_BUTTONPRESS,
+    UI_EVENT_LONG_BUTTONPRESS,
 	UI_EVENT_UPDOWN,
 	UI_EVENT_TICK,
 	UI_EVENT_LIMIT,


### PR DESCRIPTION
A better (I expect) implementation of the long press event:
- only one integer variable is shared between the ISR ad the UI task (long_button_press_tick_count).
- no synchronization is needed, as the long press check can be interrupted at any time without causing any problem. I don't know too much Cortex M0 architecture, but I expect the comparison to be atomic in the UI task. If so, event if the interrupt occurs during the comparison, the long press event will be sent and the next press event will be inhibited.
