### PR TITLE
Enhanced serial communication

### DIFF
--- a/firmware/Reload Pro.cydsn/commands.h
+++ b/firmware/Reload Pro.cydsn/commands.h
@@ -51,16 +51,17 @@ void command_version(char *);
 void command_uvlo(char *);
 void command_on(char *);
 void command_off(char *);
+void command_output(char *);
 
 #line 24 "tools/serial_keywords"
 struct command_def;
 #include <string.h>
 
-#define TOTAL_KEYWORDS 13
+#define TOTAL_KEYWORDS 14
 #define MIN_WORD_LENGTH 2
 #define MAX_WORD_LENGTH 7
 #define MIN_HASH_VALUE 2
-#define MAX_HASH_VALUE 14
+#define MAX_HASH_VALUE 15
 /* maximum key range = 13, duplicates = 0 */
 
 #ifdef __GNUC__
@@ -84,9 +85,9 @@ hash (register const char *str, register unsigned int len)
       15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
       15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
       15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
-      15, 15, 15, 15, 15, 15, 15, 15, 12, 10,
-       3, 15, 15, 15, 15, 15, 15, 15, 15,  2,
-      15,  0, 15, 15,  0,  9, 15,  7,  3, 15,
+      15, 15, 15, 15, 15, 15, 15, 15, 13, 11,
+       4, 15, 15, 15, 15, 15, 15, 15, 15,  3,
+      15,  0, 15, 15,  0, 10, 15,  8,  4, 15,
       15, 15, 15, 15, 15, 15, 15, 15
     };
   return len + asso_values[(unsigned char)str[0]];
@@ -111,6 +112,8 @@ in_word_set (register const char *str, register unsigned int len)
       {"read",command_read},
 #line 34 "tools/serial_keywords"
       {"reset",command_reset},
+#line 0 "tools/serial_keywords"
+      {"output",command_output},
 #line 32 "tools/serial_keywords"
       {"mode",command_mode},
 #line 40 "tools/serial_keywords"
@@ -179,6 +182,9 @@ in_word_set (register const char *str, register unsigned int len)
                 goto compare;
               case 12:
                 resword = &wordlist[12];
+                goto compare;
+              case 13:
+                resword = &wordlist[13];
                 goto compare;
             }
           return 0;

--- a/firmware/Reload Pro.cydsn/comms.c
+++ b/firmware/Reload Pro.cydsn/comms.c
@@ -120,7 +120,7 @@ void command_set(char *args) {
 
 void command_reset(char *args) {
 	set_output_mode(OUTPUT_MODE_FEEDBACK);
-	uart_printf("ok\r\n");
+	uart_printf("reset\r\n");
 }
 
 void command_read(char *args) {
@@ -138,6 +138,7 @@ void command_monitor(char *args) {
 		} else {
 			tick_interval = (configTICK_RATE_HZ * interval) / 1000;
 		}
+		uart_printf("monitor %d\r\n", interval);
 	}
 }
 
@@ -200,18 +201,18 @@ void command_calibrate(char *args) {
 	    uart_printf("vc_ratio           %12d\r\n", settings->calibration_settings.voltage_correction_ratio);
 	    uart_printf("raw_current_usage  %12d\r\n", get_raw_current_usage());
 	    uart_printf("raw_voltage        %12d\r\n", get_raw_voltage());
-	    uart_printf("ok\r\n");
+	    uart_printf("cal\r\n");
 		return;
 	default:
 		uart_printf("err cal: unrecognised subcommand\r\n");
 		return;
 	}
 	EEPROM_Write((uint8*)&new_settings, (uint8*)settings, sizeof(settings_t));
-	uart_printf("ok\r\n");
+	uart_printf("cal\r\n");
 }
 
 void command_bootloader(char *buf) {
-    uart_printf("ok\r\n");
+    uart_printf("bl\r\n");
     ui_event event;
     event.type = UI_EVENT_BOOTLOAD;
     xQueueSend(ui_queue, &event, 0);
@@ -238,12 +239,23 @@ void command_uvlo(char *args) {
 
 void command_on(char *args) {
 	set_output_mode(OUTPUT_MODE_FEEDBACK);
-	uart_printf("ok\r\n");
 }
 
 void command_off(char *args) {
 	set_output_mode(OUTPUT_MODE_OFF);
-	uart_printf("ok\r\n");
+}
+
+void command_output(char *args) {
+	const output_mode mode = get_output_mode();
+	switch(mode) {
+	case OUTPUT_MODE_OFF:
+		uart_printf("off\r\n");
+		break;
+	case OUTPUT_MODE_ON:
+	case OUTPUT_MODE_FEEDBACK:
+		uart_printf("on\r\n");
+		break;
+	}
 }
 
 void handle_command(char *buf) {

--- a/firmware/Reload Pro.cydsn/ui.c
+++ b/firmware/Reload Pro.cydsn/ui.c
@@ -484,6 +484,7 @@ static state_func ui_set_min_voltage(const void *arg) {
                 stage = 1;
             } else {
                 state.lower_voltage_limit = -1;
+                uart_printf("uvlo -1\r\n");
                 return (state_func)STATE_MAIN;
             }
             break;
@@ -508,6 +509,7 @@ static state_func ui_set_min_voltage(const void *arg) {
             if(event.int_arg != 1)
                 break;
             state.lower_voltage_limit = vlim;
+            uart_printf("uvlo %d\r\n", state.lower_voltage_limit / 1000);
             return (state_func)STATE_MAIN;
         case UI_EVENT_LIMIT:
             return (state_func){overlimit, (void *)event.int_arg, 0};

--- a/firmware/Reload Pro.cydsn/utils.c
+++ b/firmware/Reload Pro.cydsn/utils.c
@@ -12,6 +12,7 @@
 
 #include <FreeRTOS.h>
 #include <stdio.h>
+#include "comms.h"
 #include "config.h"
 
 #ifdef USE_SPLASHSCREEN
@@ -99,17 +100,20 @@ void set_output_mode(output_mode mode) {
 		Opamp_Stop();
 		Opamp_Out_Write(0);
 		Opamp_Out_SetDriveMode(Opamp_Out_DM_STRONG);
+		uart_printf("off\r\n");
 		break;
 	case OUTPUT_MODE_ON:
 		// Stop the opamp and set the gate high
 		Opamp_Stop();
 		Opamp_Out_Write(1);
 		Opamp_Out_SetDriveMode(Opamp_Out_DM_STRONG);
+		uart_printf("on\r\n");
 		break;
 	case OUTPUT_MODE_FEEDBACK:
 		// Start the opamp and set the pin to hi-z
 		Opamp_Out_SetDriveMode(Opamp_Out_DM_ALG_HIZ);
 		Opamp_Start();
+		uart_printf("on\r\n");
 		break;
 	}
 }


### PR DESCRIPTION
- Added command 'output' to get the actual output state of the device
- Changed the response of 'bl', 'cal', 'monitor', 'reset', 'on' and 'off' from 'ok' to 'bl', 'cal', ....
- Added 'on', 'off' and 'uvlo' responses when the states/settings are changed with the ReLoad Pro device.